### PR TITLE
Add Megaphone and Texting With Jill (Checkfinders) with option to start with them in inventory

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -105,7 +105,14 @@ class GatorWorld(World):
             item: data.base_quantity_in_item_pool for item, data in item_table.items()
         }
 
-        ## TODO: start_inventory_from_pool handling
+        # If start with checkfinders on, add them into the start inventory, otherwise add them to the itempool
+        if self.options.start_with_checkfinders:
+            self.multiworld.push_precollected(self.create_item(item_table.short_to_long("megaphone")))
+            self.multiworld.push_precollected(self.create_item(item_table.short_to_long("texting")))
+        else:
+            items_to_create[item_table.short_to_long("megaphone")] = 1
+            items_to_create[item_table.short_to_long("texting")] = 1
+
         for item, quantity in items_to_create.items():
             for i in range(0, quantity):
                 gator_item: GatorItem = self.create_item(item)

--- a/data/items.json
+++ b/data/items.json
@@ -681,6 +681,28 @@
             "classification": "filler",
             "base_quantity_in_item_pool": 1,
             "item_groups": "Craft"
+        },
+        "Megaphone (Item)": {
+            "long_name": "Megaphone (Item)",
+            "short_name": "megaphone",
+            "item_id": 100000063,
+            "client_name_id": "Item_SearchNPCs",
+            "client_resource_amount": null,
+            "client_item_type": "Item",
+            "classification": "useful",
+            "base_quantity_in_item_pool": 0,
+            "item_groups": "Item"
+        },
+        "Texting With Jill (Item)": {
+            "long_name": "Texting With Jill (Item)",
+            "short_name": "texting",
+            "item_id": 100000064,
+            "client_name_id": "Item_SearchObjects",
+            "client_resource_amount": null,
+            "client_item_type": "Item",
+            "classification": "useful",
+            "base_quantity_in_item_pool": 0,
+            "item_groups": "Item"
         }
     }
 ]

--- a/options.py
+++ b/options.py
@@ -24,10 +24,10 @@ class HarderRangedQuests(Toggle):
     display_name = "Harder Ranged Quests"
 
 
-# class StartWithCheckFinders(Toggle):
-#     """Start with Megaphone and Text Jill items in inventory for finding checks."""
-#     internal_name = "start_with_check_finder"
-#     display_name = "Start With Check Finders"
+class StartWithCheckFinders(Toggle):
+    """Start with Megaphone and Text Jill items in inventory for finding checks."""
+    internal_name = "start_with_check_finder"
+    display_name = "Start With Check Finders"
 
 
 @dataclass
@@ -35,6 +35,7 @@ class GatorOptions(PerGameCommonOptions):
     start_with_freeplay: StartWithFreeplay
     require_shield_jump: RequireShieldJump
     harder_ranged_quests: HarderRangedQuests
+    start_with_checkfinders: StartWithCheckFinders
     start_inventory_from_pool: StartInventoryPool
 
 
@@ -43,11 +44,15 @@ gator_options_presets = {
         "start_with_freeplay": True,
         "require_shield_jump": False,
         "harder_ranged_quests": False,
+        "start_with_checkfinders": True,
     }
 }
 
 gator_option_groups: Dict[str, Dict[str, Any]] = [
     OptionGroup(
         "Logic Options", [StartWithFreeplay, RequireShieldJump, HarderRangedQuests]
+    ),
+    OptionGroup(
+        "Convenience Options", [StartWithCheckFinders]
     )
 ]


### PR DESCRIPTION
Adds the two in-game checkfinding tools (Megaphone for NPCs and Texting With Jill for breakables/races) into the list of valid items. Adds an option "start_with_checkfinders" to allow the player to start with these items in inventory if True, otherwise, puts the items into the item pool for randomization.

Tested local generation with option True and False and verified that spoiler log contained the correct for each generation.

Closes #7 